### PR TITLE
Refactor CommandParser command registration

### DIFF
--- a/src/farming/commands/CommandParser.java
+++ b/src/farming/commands/CommandParser.java
@@ -10,7 +10,9 @@ public class CommandParser {
     private final Map<String, Command> commands = new HashMap<>();
 
     public CommandParser() {
-        commands.put("show", new ShowCommand()); // Basiskommandogruppe
+        // register all commands here
+        commands.put("show barn", new ShowCommand());
+        commands.put("show board", new ShowBoardCommand());
         commands.put("show market", new ShowMarketCommand());
         // commands.put("sell", new SellCommand());
         // commands.put("plant", new PlantCommand());
@@ -27,16 +29,13 @@ public class CommandParser {
                 System.out.println("Error, missing show target");
                 return false;
             }
-
-            return switch (parts[1]) {
-                case "barn"   -> new ShowCommand().execute(parts, player, game);
-                case "board"  -> new ShowBoardCommand().execute(parts, player, game);
-                case "market" -> new ShowMarketCommand().execute(parts, player, game);
-                default       -> {
-                    System.out.println("Error, invalid show target");
-                    yield false;
-                }
-            };
+            String key2 = keyword + " " + parts[1].toLowerCase();
+            Command command = commands.get(key2);
+            if (command == null) {
+                System.out.println("Error, invalid show target");
+                return false;
+            }
+            return command.execute(parts, player, game);
         }
 
         Command command = commands.get(keyword);


### PR DESCRIPTION
## Summary
- register each show command in the `commands` map
- retrieve commands from the map in `handle()` instead of instantiating them

## Testing
- `javac -d out $(find src -name '*.java')`
- `java -cp out farming.test.QueensFarming | head` *(fails: No line found)*

------
https://chatgpt.com/codex/tasks/task_e_686febef3f5c832db155eaa0b6c84a72