### PR TITLE
Refactor CommandParser to use registry

### DIFF
--- a/src/farming/commands/CommandParser.java
+++ b/src/farming/commands/CommandParser.java
@@ -7,18 +7,28 @@ import farming.view.GameView;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-
-import static java.util.logging.Level.parse;
+import java.util.function.Function;
 
 public class CommandParser {
     private final Player player;
     private final GameView view;
     private final Game game;
+    private final Map<String, Function<String[], Optional<Command>>> registry;
 
     public CommandParser(Player player, GameView view, Game game) {
         this.player = player;
         this.view = view;
         this.game = game;
+        this.registry = new HashMap<>();
+
+        // register commands
+        registry.put("show", parts -> {
+            if (parts.length == 2 && parts[1].equalsIgnoreCase("barn")) {
+                return Optional.of(new ShowBarnCommand(player, view));
+            }
+            System.err.println("Error, unknown show command");
+            return Optional.empty();
+        });
     }
 
     public boolean handle(String input) {
@@ -37,19 +47,12 @@ public class CommandParser {
 
         String keyword = parts[0].toLowerCase();
 
-        switch (keyword) {
-            case "show":
-                if (parts.length == 2 && parts[1].equalsIgnoreCase("barn")) {
-                    return Optional.of(new ShowBarnCommand(player, view));
-                }
-                // Weitere show-Befehle hier ergänzen
-                System.err.println("Error, unknown show command");
-                break;
-
-            default:
-                System.err.println("Error, unknown command");
+        Function<String[], Optional<Command>> factory = registry.get(keyword);
+        if (factory != null) {
+            return factory.apply(parts);
         }
 
+        System.err.println("Error, unknown command");
         return Optional.empty();
     }
 


### PR DESCRIPTION
## Summary
- remove unused logging import
- maintain a registry of command keywords in `CommandParser`
- initialize registry in the constructor and replace switch logic

## Testing
- `javac @sources.txt` (compiles successfully)

------
https://chatgpt.com/codex/tasks/task_e_687398409e48832d99c69b4300835837